### PR TITLE
URL コピーに関する修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,9 +54,12 @@ export default function Home() {
       `title=${eventObject.title}&start=${eventObject.startDate}&end=${eventObject.endDate}&location=${eventObject.location}`
     );
   };
+
+  const renderedUrl = `https://calendar-add.vercel.app/render/?${param}`;
+
   const copyToClipboard = () => {
     navigator.clipboard
-      .writeText(`/render/?${param}`)
+      .writeText(renderedUrl)
       .then(() => {
         setSnackbarOpen(true);
       })
@@ -64,8 +67,6 @@ export default function Home() {
         console.error("コピーに失敗しました: ", err);
       });
   };
-
-  const renderedUrl = `https://calendar-add.vercel.app/render/?${param}`;
 
   const router = useRouter();
   const path = router.pathname;


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- 無し

## ⛏ 変更内容 / Details of Changes

- 出力された URL 欄を押下した際にコピーされる文字列が全体 URL ではなく、/render 以降の文字列だったため、`renderedUrl` クリップボードに書き込むように修正しました🙏 [361139796683edf13e91b1d0315e61eba1ebd0ea]

## 📸 スクリーンショット / Screenshots

- 無し

## 💬 備考 / Remarks

- 仕様としては、出力されてる URL (`renderedUrl`) がクリップボードにコピーされれば良いのかな？何も聞かずにいきなり PR 出しちゃったので、間違ってたらごめんなさい！🙏

こちら、よろしくお願いします🙏